### PR TITLE
much png download. such smaller. very browser compatibility. wow.

### DIFF
--- a/src/dogr.js
+++ b/src/dogr.js
@@ -22,7 +22,7 @@ prefillTextArea(providedLines);
 
 document.getElementById('wow').onclick = writeAllDogeContent;
 document.getElementById('download').onclick = function(){
-    var dataURL = canvas.toDataURL();
+    var dataURL = canvas.toDataURL('image/jpeg');
     window.location.href = dataURL;
 };
 


### PR DESCRIPTION
The URL for the serialized PNG created by canvas.toDataURL() was over 800k characters (about 640kb), and it was crashing Chrome on Android. JPG (even at the highest quality) is almost 1/10th the size and seems to work better. Might be preferable if there's no need for transparency.

Thanks for a Sunday laugh :)
