### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#dogr
+# dogr
 [http://dogr.io](http://dogr.io)
 
 ![](http://i.imgur.com/zUiO1Xz.png)
 
-##so smart. wow.
+## so smart. wow.
 [http://dogr.io/wow/sosmart/verytextdetection/](http://dogr.io/wow/sosmart/verytextdetection/)
 
-##such service.
+## such service.
 [http://dogr.io/wow/sosmart/verytextdetection/soservice.png](http://dogr.io/wow/sosmart/verytextdetection/soservice.png)
 
-##many manual.
+## many manual.
 [http://dogr.io/wow/many%20manual/such%20choice/doge%20multi%20use.png?split=false](http://dogr.io/wow/many%20manual/such%20choice/doge%20multi%20use.png?split=false)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
